### PR TITLE
Change column name to add sync/async

### DIFF
--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -63,7 +63,7 @@ def _raw_to_jenkins(dataframe, csv_path):
         dataframe['data_received'].describe(percentiles=[0.95]).iloc[5] * BYTE_TO_MBYTE,
     ]
 
-    write_jenkins_plot_csv(csv_path, '@TEST_NAME@_@PERF_TEST_TOPIC@', values)
+    write_jenkins_plot_csv(csv_path, '@TEST_NAME_SYNC@_@PERF_TEST_TOPIC@', values)
 
     json_path = os.path.splitext(csv_path)[0] + '.benchmark.json'
     json_values = {

--- a/test/test_performance.py.in
+++ b/test/test_performance.py.in
@@ -63,7 +63,7 @@ def _raw_to_jenkins(dataframe, csv_path):
         dataframe['data_received'].describe(percentiles=[0.95]).iloc[5] * BYTE_TO_MBYTE,
     ]
 
-    write_jenkins_plot_csv(csv_path, '@TEST_NAME_SYNC@_@PERF_TEST_TOPIC@', values)
+    write_jenkins_plot_csv(csv_path, '@TEST_NAME_SYNC_TOPIC@', values)
 
     json_path = os.path.splitext(csv_path)[0] + '.benchmark.json'
     json_values = {


### PR DESCRIPTION
Changing this input, the new name of the columns in `.csv` result files will have the `sync/async` tag.
This is needed to separate them when plotting the results.